### PR TITLE
Make Search-on-open optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,3 +49,11 @@ A couple of options you may want to override in your .vimrc are:
     let g:TurboMarkMax = 30  (defaults to 100)
 
     This is the maximum number of marked lines that TurboMark will remember
+
+
+    let g:TurboMarkSearchOnOpen = 1
+
+    This will start a vim case-insensitive search when the quickfix window is
+    opened so you can start typing a search for a mark as soon as you activate
+    TurboMark.  Just remember to press a double RETURN after your search, one to
+    end your search and one to navigate to the file/line you want.

--- a/doc/TurboMark.txt
+++ b/doc/TurboMark.txt
@@ -11,11 +11,12 @@ Commands:
                                                                        
 :TurboFind                                              *:TurboFind*
                             Populate the quickfix window with all the entries
-                            in the marklist, open the quickfix window and enter
-                            search mode. This allows you to quickly find any
-                            line you've marked; just remember to press a double
-                            RETURN after your search, one to end your search
-                            and one to navigate to the file/line you want.
+                            in the marklist, open the quickfix window.
+
+                            Note that previous versions automatically entered
+                            search mode when the quickfix window was opened.
+                            That behavior can now be activated by setting
+                            g:TurboMarkSearchOnOpen (see |TurboMark-settings|).
 
                             You might want to close the quickfix window with
                             :cclose after you're done.
@@ -50,3 +51,11 @@ A couple of options you may want to override in your .vimrc are:
     let g:TurboMarkMax = 30  (defaults to 100)
 
     This is the maximum number of marked lines that TurboMark will remember
+
+
+    let g:TurboMarkSearchOnOpen = 1
+
+    This will start a vim case-insensitive search when the quickfix window is
+    opened so you can start typing a search for a mark as soon as you activate
+    TurboMark.  Just remember to press a double RETURN after your search, one to
+    end your search and one to navigate to the file/line you want.

--- a/plugin/TurboMark.vim
+++ b/plugin/TurboMark.vim
@@ -13,6 +13,7 @@ let g:TurboMark = {}
 let s:marklist = []
 let g:TurboMarkListFile = expand('$HOME') . "/.TurboMarkList.txt"
 let g:TurboMarkMax = 100
+let g:TurboMarkSearchOnOpen = 0
 
 function g:TurboMark.Init()
     if filereadable(g:TurboMarkListFile)
@@ -60,7 +61,9 @@ function g:TurboMark.Find()
     cgetexpr l:reversed
     copen
     let g:TurboMark.in_turbomark = 1
-    call feedkeys('/\c')
+    if g:TurboMarkSearchOnOpen == 1
+        call feedkeys('/\c')
+    endif
 endfunction
 
 command TurboMark call g:TurboMark.Mark()


### PR DESCRIPTION
Adds a variable, `g:TurboMarkSearchOnOpen`, to control entering search mode when the quickfix window is opened.

I felt that inserting the `/c` is so different from any other quickfix plugin that it makes using TurboMark very confusing at first. I understand the idea of being able to search instantly, but ideally there would be a way to support both search and using other forms of navigation, such as how [ctrlp](https://github.com/kien/ctrlp.vim) works.

In this version, the automatic search defaults to off and can be enabled by a user who has a desire to do so.

Fixes #1
